### PR TITLE
Fixed bug

### DIFF
--- a/Sources/Classes/JTAppleCalendarDelegates.swift
+++ b/Sources/Classes/JTAppleCalendarDelegates.swift
@@ -260,7 +260,8 @@ extension JTAppleCalendarView: UICollectionViewDataSource, UICollectionViewDeleg
         if let
             delegate = self.delegate,
             dateDeSelectedByUser = dateFromPath(indexPath),
-            cell = collectionView.cellForItemAtIndexPath(indexPath) as? JTAppleDayCell {
+            cell = collectionView.cellForItemAtIndexPath(indexPath) as? JTAppleDayCell
+        where cellWasNotDisabledOrHiddenByTheUser(cell) {
             let cellState = cellStateFromIndexPath(indexPath, withDate: dateDeSelectedByUser)
             return delegate.calendar(self, canDeselectDate: dateDeSelectedByUser, cell: cell.cellView, cellState:  cellState)
         }

--- a/Sources/Classes/JTAppleCalendarDelegates.swift
+++ b/Sources/Classes/JTAppleCalendarDelegates.swift
@@ -262,8 +262,7 @@ extension JTAppleCalendarView: UICollectionViewDataSource, UICollectionViewDeleg
             dateDeSelectedByUser = dateFromPath(indexPath),
             cell = collectionView.cellForItemAtIndexPath(indexPath) as? JTAppleDayCell {
             let cellState = cellStateFromIndexPath(indexPath, withDate: dateDeSelectedByUser)
-            delegate.calendar(self, canDeselectDate: dateDeSelectedByUser, cell: cell.cellView, cellState:  cellState)
-            return true
+            return delegate.calendar(self, canDeselectDate: dateDeSelectedByUser, cell: cell.cellView, cellState:  cellState)
         }
         return false
     }


### PR DESCRIPTION
JTAppleCalendarViewDelegate's canDeselectDate return value was being ignored
